### PR TITLE
fix: filter out library components from wwVariableOptions

### DIFF
--- a/src/components/Request.vue
+++ b/src/components/Request.vue
@@ -321,6 +321,8 @@ export default {
             });;
         },
         wwVariableOptions() {
+            console.log('wwVariables', this.wwVariables);
+
             return this.wwVariables
                 .filter(variable => variable.type === 'array')
                 .map(variable => {

--- a/src/components/Request.vue
+++ b/src/components/Request.vue
@@ -315,7 +315,10 @@ export default {
             return [
                 ...(this.websiteVariables ? Object.values(this.websiteVariables) : []),
                 ...(this.componentVariables ? Object.values(this.componentVariables) : []),
-            ];
+            ],filter(variable => {
+                if (variable.componentType === 'libraryComponent') return false;
+                return true;
+            });;
         },
         wwVariableOptions() {
             return this.wwVariables

--- a/src/components/Request.vue
+++ b/src/components/Request.vue
@@ -315,14 +315,12 @@ export default {
             return [
                 ...(this.websiteVariables ? Object.values(this.websiteVariables) : []),
                 ...(this.componentVariables ? Object.values(this.componentVariables) : []),
-            ],filter(variable => {
+            ].filter(variable => {
                 if (variable.componentType === 'libraryComponent') return false;
                 return true;
             });;
         },
         wwVariableOptions() {
-            console.log('wwVariables', this.wwVariables);
-
             return this.wwVariables
                 .filter(variable => variable.type === 'array')
                 .map(variable => {


### PR DESCRIPTION
- Updated the wwVariableOptions computed property to exclude variables of type 'libraryComponent', ensuring only relevant variables are included in the options returned.